### PR TITLE
Fix

### DIFF
--- a/src/app/dashboard/problems/[id]/page.tsx
+++ b/src/app/dashboard/problems/[id]/page.tsx
@@ -180,7 +180,7 @@ function ProblemContent() {
                   <div className="flex items-center gap-2 mb-2">
                     <Clock className="w-5 h-5 text-[#999999]" />
                     <p className="text-2xl font-mono font-bold text-[#999999]">
-                      0:{timeElapsed.toString().padStart(2, "0")}
+                      {Math.floor(timeElapsed / 60)}:{(timeElapsed % 60).toString().padStart(2, "0")}
                     </p>
                   </div>
                 </div>
@@ -551,7 +551,7 @@ function ProblemContent() {
                         Time Elapsed
                       </p>
                       <p className="text-2xl font-mono font-bold text-white">
-                        0:{timeElapsed.toString().padStart(2, "0")}
+                        {Math.floor(timeElapsed / 60)}:{(timeElapsed % 60).toString().padStart(2, "0")}
                       </p>
                     </div>
                   </div>

--- a/src/app/dashboard/problems/page.tsx
+++ b/src/app/dashboard/problems/page.tsx
@@ -122,7 +122,7 @@ function ProblemContent() {
                   Time
                 </p>
                 <p className="text-2xl font-mono font-bold text-[#22c55e]">
-                  0:{timeElapsed.toString().padStart(2, "0")}
+                  {Math.floor(timeElapsed / 60)}:{(timeElapsed % 60).toString().padStart(2, "0")}
                 </p>
               </div>
               <div>
@@ -289,7 +289,7 @@ function ProblemContent() {
                     Time Elapsed
                   </p>
                   <p className="text-2xl font-mono font-bold text-white">
-                    0:{timeElapsed.toString().padStart(2, "0")}
+                    {Math.floor(timeElapsed / 60)}:{(timeElapsed % 60).toString().padStart(2, "0")}
                   </p>
                 </div>
               </div>


### PR DESCRIPTION
The timer display was hardcoded to show "0:{seconds}" which would display incorrectly once elapsed time exceeded 59 seconds (e.g., showing "0:125" instead of "2:05"). Changed to properly calculate minutes and seconds from the total elapsed time.